### PR TITLE
Only include 'lib.js' when publishing to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "object-has-keys",
   "version": "0.2.2",
-  "description": "A javascript utility to check if given object has a set of keys.",
+  "description": "Utility to check if given object has a set of keys.",
   "main": "lib.js",
+  "files" : [
+    "lib.js"
+  ],
   "scripts": {
     "test": "mocha",
     "build": "babel index.js -o lib.js"


### PR DESCRIPTION
Without the `files` key in `package.json` you will be exporting everything in your repository to the NPM registry. Thus, it is recommended to have a list of `files` that need to go to NPM.

Another alternative is to use a `.npmignore` file in the root of the directory which as the name suggests will ignore files that have been listed and won't publish it to NPM.

Read more [here](https://github.com/npm/npm/wiki/Files-and-Ignores).